### PR TITLE
Code Bug Fix

### DIFF
--- a/xicorpy/foci.py
+++ b/xicorpy/foci.py
@@ -40,6 +40,8 @@ class FOCI:
         else:
             codec = compute_conditional_dependence_1d(self.y_, self.x_df)
 
+        if not codec:
+            return 0, 0
         next_p = max(codec, key=lambda k: codec[k])
         return next_p, codec[next_p]
 


### PR DESCRIPTION
Currently raises an error when all columns are exhausted during CoDec search.

Returning 0,0 to fix it.